### PR TITLE
Added current attribute value for internal use by the field.

### DIFF
--- a/src/Http/Controllers/SettingsController.php
+++ b/src/Http/Controllers/SettingsController.php
@@ -104,7 +104,9 @@ class SettingsController extends Controller
                     return;
                 }
 
-                $tempResource = new \Laravel\Nova\Support\Fluent;
+                $tempResource = new \Laravel\Nova\Support\Fluent([
+                    $field->attribute => $settingsClass->{$field->attribute},
+                ]);
                 $field->fill($request, $tempResource);
 
                 $settingsClass->{$field->attribute} = $tempResource->{$field->attribute};


### PR DESCRIPTION
For cases where fields require access to the current value of the attribute stored in the model (setting) through the `fill()` process